### PR TITLE
adds docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:jammy
+
+WORKDIR /home/project
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update && apt-get install -y freerdp2-x11 wget lsb-release gnupg virtualbox
+
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list \
+    && apt update && apt install -y vagrant 
+
+RUN export VER="1.5.1" \
+    && wget https://releases.hashicorp.com/packer/${VER}/packer_${VER}_linux_amd64.zip \
+    && unzip packer_${VER}_linux_amd64.zip \
+    && mv packer /usr/local/bin \
+    && packer --help
+


### PR DESCRIPTION
Almost got it working:

```
docker run -v $PWD:/home/project -v /dev/vboxdrv:/dev/vboxdrv -it vagrant_builder packer build --only=virtualbox-iso -var 'iso_url=/home/project/iso/windows10.iso' -var 'iso_checksum=06fd4a512c5f3e8d16f77ca909c4f20110329b8cdd5ad101e2afc0d58b06d416' /home/project/windows_10.json
virtualbox-iso: output will be in this color.

==> virtualbox-iso: Retrieving ISO
==> virtualbox-iso: Trying /home/project/iso/windows10.iso
==> virtualbox-iso: Trying /home/project/iso/windows10.iso?checksum=sha256%3A06fd4a512c5f3e8d16f77ca909c4f20110329b8cdd5ad101e2afc0d58b06d416
==> virtualbox-iso: /home/project/iso/windows10.iso?checksum=sha256%3A06fd4a512c5f3e8d16f77ca909c4f20110329b8cdd5ad101e2afc0d58b06d416 => /home/project/packer_cache/dd35770f70deec15cee38b2889da075378e7f690.iso
==> virtualbox-iso: Creating floppy disk...
    virtualbox-iso: Copying files flatly from floppy_files
    virtualbox-iso: Copying file: ./answer_files/10/Autounattend.xml
    virtualbox-iso: Copying file: ./floppy/WindowsPowershell.lnk
    virtualbox-iso: Copying file: ./floppy/PinTo10.exe
    virtualbox-iso: Copying file: ./scripts/fixnetwork.ps1
    virtualbox-iso: Copying file: ./scripts/disable-screensaver.ps1
    virtualbox-iso: Copying file: ./scripts/disable-winrm.ps1
    virtualbox-iso: Copying file: ./scripts/enable-winrm.ps1
    virtualbox-iso: Copying file: ./scripts/microsoft-updates.bat
    virtualbox-iso: Copying file: ./scripts/win-updates.ps1
    virtualbox-iso: Done copying files from floppy_files
    virtualbox-iso: Collecting paths from floppy_dirs
    virtualbox-iso: Resulting paths from floppy_dirs : []
    virtualbox-iso: Done copying paths from floppy_dirs
==> virtualbox-iso: Creating ephemeral key pair for SSH communicator...
==> virtualbox-iso: Created ephemeral SSH key pair for communicator
==> virtualbox-iso: Creating virtual machine...
==> virtualbox-iso: Creating hard drive...
==> virtualbox-iso: Attaching floppy disk...
==> virtualbox-iso: Creating forwarded port mapping for communicator (SSH, WinRM, etc) (host port 2960)
==> virtualbox-iso: Starting the virtual machine...
==> virtualbox-iso: Error starting VM: VBoxManage error: VBoxManage: error: The virtual machine 'windows_10' has terminated unexpectedly during startup with exit code 1 (0x1)
==> virtualbox-iso: VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component MachineWrap, interface IMachine
==> virtualbox-iso: Deregistering and deleting VM...
==> virtualbox-iso: Deleting output directory...
Build 'virtualbox-iso' errored: Error starting VM: VBoxManage error: VBoxManage: error: The virtual machine 'windows_10' has terminated unexpectedly during startup with exit code 1 (0x1)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component MachineWrap, interface IMachine

==> Some builds didn't complete successfully and had errors:
--> virtualbox-iso: Error starting VM: VBoxManage error: VBoxManage: error: The virtual machine 'windows_10' has terminated unexpectedly during startup with exit code 1 (0x1)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component MachineWrap, interface IMachine

==> Builds finished but no artifacts were created.

```